### PR TITLE
Remove circe generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.class
 .idea
 .bloop
+.bsp
 target/
 **/.DS_Store
 .vscode/

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ val oauth2Dependencies = {
 }
 
 val mimaSettings = mimaPreviousArtifacts := Set(
-  organization.value %% name.value % "0.1.0"
+//  organization.value %% name.value % "0.1.0" // TODO Define a process for resetting this after release
 )
 
 lazy val oauth2 = project.settings(

--- a/build.sbt
+++ b/build.sbt
@@ -74,8 +74,6 @@ val commonDependencies = {
   val circe = Seq(
     "io.circe" %% "circe-parser" % Versions.circe,
     "io.circe" %% "circe-core" % Versions.circe,
-    "io.circe" %% "circe-generic" % Versions.circe,
-    "io.circe" %% "circe-generic-extras" % Versions.circe,
     "io.circe" %% "circe-refined" % Versions.circe
   )
 

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
@@ -3,7 +3,6 @@ package com.ocadotechnology.sttp.oauth2
 import java.time.Instant
 import com.ocadotechnology.sttp.oauth2.common._
 import io.circe.Decoder
-import io.circe.generic.extras.semiauto._
 import io.circe.refined._
 import sttp.client.ResponseAs
 import com.ocadotechnology.sttp.oauth2.common.Error.OAuth2Error
@@ -33,9 +32,16 @@ object Introspection {
 
   object TokenIntrospectionResponse {
 
-    import com.ocadotechnology.sttp.oauth2.circe._
-
-    implicit val decoder: Decoder[TokenIntrospectionResponse] = deriveConfiguredDecoder
+    implicit val decoder: Decoder[TokenIntrospectionResponse] =
+      Decoder.forProduct7(
+        "client_id",
+        "domain",
+        "exp",
+        "active",
+        "authorities",
+        "scope",
+        "token_type"
+      )(TokenIntrospectionResponse.apply)
 
   }
 

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Oauth2TokenResponse.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Oauth2TokenResponse.scala
@@ -1,11 +1,8 @@
 package com.ocadotechnology.sttp.oauth2
 
 import io.circe.Decoder
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.duration.DurationLong
 
 case class Oauth2TokenResponse(
   accessToken: Secret[String],
@@ -22,7 +19,21 @@ case class Oauth2TokenResponse(
 )
 
 object Oauth2TokenResponse {
-  implicit val circeConf: Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults
-  implicit val decoder: Decoder[Oauth2TokenResponse] = deriveConfiguredDecoder[Oauth2TokenResponse]
-  implicit val decoderFiniteDuration: Decoder[FiniteDuration] = Decoder.decodeLong.map(DurationLong(_).seconds)
+  import com.ocadotechnology.sttp.oauth2.circe._
+
+  implicit val decoder: Decoder[Oauth2TokenResponse] =
+    Decoder.forProduct11(
+      "access_token",
+      "refresh_token",
+      "expires_in",
+      "user_name",
+      "domain",
+      "user_details",
+      "roles",
+      "scope",
+      "security_level",
+      "user_id",
+      "token_type"
+    )(Oauth2TokenResponse.apply)
+
 }

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/RefreshTokenResponse.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/RefreshTokenResponse.scala
@@ -1,11 +1,8 @@
 package com.ocadotechnology.sttp.oauth2
 
 import io.circe.Decoder
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.duration.DurationLong
 
 private[oauth2] final case class RefreshTokenResponse(
   accessToken: Secret[String],
@@ -39,7 +36,22 @@ private[oauth2] final case class RefreshTokenResponse(
 }
 
 private[oauth2] object RefreshTokenResponse {
-  implicit val circeConf: Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults
-  implicit val decoder: Decoder[RefreshTokenResponse] = deriveConfiguredDecoder[RefreshTokenResponse]
-  implicit val decoderFiniteDuration: Decoder[FiniteDuration] = Decoder.decodeLong.map(DurationLong(_).seconds)
+
+  import com.ocadotechnology.sttp.oauth2.circe._
+
+  implicit val decoder: Decoder[RefreshTokenResponse] =
+    Decoder.forProduct11(
+      "access_token",
+      "refresh_token",
+      "expires_in",
+      "user_name",
+      "domain",
+      "user_details",
+      "roles",
+      "scope",
+      "security_level",
+      "user_id",
+      "token_type"
+    )(RefreshTokenResponse.apply)
+
 }

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/TokenUserDetails.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/TokenUserDetails.scala
@@ -1,8 +1,6 @@
 package com.ocadotechnology.sttp.oauth2
 
 import io.circe.Decoder
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 
 case class TokenUserDetails(
   username: String,
@@ -16,6 +14,17 @@ case class TokenUserDetails(
 )
 
 object TokenUserDetails {
-  implicit val circeConf: Configuration = Configuration.default
-  implicit val decoder: Decoder[TokenUserDetails] = deriveConfiguredDecoder[TokenUserDetails]
+
+  implicit val decoder: Decoder[TokenUserDetails] =
+    Decoder.forProduct8(
+      "username",
+      "name",
+      "forename",
+      "surname",
+      "mail",
+      "cn",
+      "sn",
+      "given_name"
+    )(TokenUserDetails.apply)
+
 }

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/UserInfo.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/UserInfo.scala
@@ -1,8 +1,6 @@
 package com.ocadotechnology.sttp.oauth2
 
 import io.circe.Decoder
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 
 /** Models user info as defined in open id standard
   * @see https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
@@ -33,7 +31,7 @@ final case class UserInfo(
   email: Option[String],
   emailVerified: Option[Boolean],
   locale: Option[String],
-  // TODO - fields below are non-standard and should be removed when introducing cutom UserInfoType with decoder
+  // TODO - fields below are non-standard and should be removed when introducing custom UserInfoType with decoder
   sites: List[String] = Nil,
   banners: List[String] = Nil,
   regions: List[String] = Nil,
@@ -41,6 +39,23 @@ final case class UserInfo(
 )
 
 object UserInfo {
-  implicit val circeConf: Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults
-  implicit val decoder: Decoder[UserInfo] = deriveConfiguredDecoder[UserInfo]
+
+  implicit val decoder: Decoder[UserInfo] =
+    Decoder.forProduct14(
+      "sub",
+      "name",
+      "given_name",
+      "family_name",
+      "job_title",
+      "domain",
+      "preferred_username",
+      "email",
+      "email_verified",
+      "locale",
+      "sites",
+      "banners",
+      "regions",
+      "fulfillment_contexts"
+    )(UserInfo.apply)
+
 }

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/circe.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/circe.scala
@@ -1,15 +1,12 @@
 package com.ocadotechnology.sttp.oauth2
 
 import io.circe.Decoder
-import io.circe.generic.extras.Configuration
 import cats.syntax.all._
 
 import scala.concurrent.duration.DurationLong
 import scala.concurrent.duration.FiniteDuration
 
 object circe {
-
-  implicit val circeConf: Configuration = Configuration.default.withDefaults.withSnakeCaseMemberNames.withSnakeCaseConstructorNames
 
   implicit val decoderSeconds: Decoder[FiniteDuration] = Decoder.decodeLong.map(_.seconds)
 

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/IntrospectionSerializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/IntrospectionSerializationSpec.scala
@@ -1,0 +1,39 @@
+package com.ocadotechnology.sttp.oauth2
+
+import com.ocadotechnology.sttp.oauth2.Introspection.TokenIntrospectionResponse
+import com.ocadotechnology.sttp.oauth2.common.Scope
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.circe.literal._
+import org.scalatest.OptionValues
+
+import java.time.Instant
+
+class IntrospectionSerializationSpec extends AnyWordSpec with Matchers with OptionValues {
+  "Token" should {
+    "deserialize token introspection response" in {
+      val clientId = "Client ID"
+      val domain = "zoo"
+      val exp = Instant.EPOCH
+      val active = false
+      val authorities = List("aaa", "bbb")
+      val scope = "cfc.first-app_scope"
+      val tokenType = "Bearer"
+
+      val json = json"""{
+            "client_id": $clientId,
+            "domain": $domain,
+            "exp": ${exp.toString},
+            "active": $active,
+            "authorities": $authorities,
+            "scope": $scope,
+            "token_type": $tokenType
+          }"""
+
+      json.as[TokenIntrospectionResponse] shouldBe Right(
+        TokenIntrospectionResponse(clientId, domain, exp, active, authorities, Scope.of(scope).value, tokenType)
+      )
+
+    }
+  }
+}

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/TokenSerializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/TokenSerializationSpec.scala
@@ -8,23 +8,26 @@ import scala.concurrent.duration.DurationLong
 
 class TokenSerializationSpec extends AnyWordSpec with Matchers {
 
+  val accessTokenValue = "xxxxxxxxxxxxxxxxxx"
+  val accessToken = Secret(accessTokenValue)
+  val expiresIn: Long = 1800
+  val userName = "john.doe"
+  val domain = "exampledomain"
+  val name = "John Doe"
+  val forename = "John"
+  val surname = "Doe"
+  val mail = "john.doe@example.com"
+  val roles = Set[String]("manager")
+  val scope = ""
+  val securityLevel: Long = 384
+  val userId = "c0a8423e-7274-184b"
+  val tokenType = "Bearer"
+
   "Token" should {
-    "deserialize token" in {
-      val accessTokenValue = "xxxxxxxxxxxxxxxxxx"
-      val accessToken = Secret(accessTokenValue)
+
+    "deserialize OAuth2Token" in {
       val refreshToken = "yyyyyyyyyyyyyyyyyyyy"
-      val expiresIn: Long = 1800
-      val userName = "john.doe"
-      val domain = "exampledomain"
-      val name = "John Doe"
-      val forename = "John"
-      val surname = "Doe"
-      val mail = "john.doe@example.com"
-      val roles = Set[String]("manager")
-      val scope = ""
-      val securityLevel: Long = 384
-      val userId = "c0a8423e-7274-184b"
-      val tokenType = "Bearer"
+
       val jsonToken =
         json"""{
               "access_token": $accessTokenValue,
@@ -40,7 +43,7 @@ class TokenSerializationSpec extends AnyWordSpec with Matchers {
                   "mail": $mail,
                   "cn": $name,
                   "sn": $surname,
-                  "givenName": $forename
+                  "given_name": $forename
               },
               "roles": $roles,
               "scope": $scope,
@@ -51,6 +54,50 @@ class TokenSerializationSpec extends AnyWordSpec with Matchers {
 
       jsonToken.as[Oauth2TokenResponse] shouldBe Right(
         Oauth2TokenResponse(
+          accessToken,
+          refreshToken,
+          expiresIn.seconds,
+          userName,
+          domain,
+          TokenUserDetails(userName, name, forename, surname, mail, name, surname, forename),
+          roles,
+          scope,
+          securityLevel,
+          userId,
+          tokenType
+        )
+      )
+    }
+
+    "deserialize RefreshTokenResponse" in {
+      val refreshToken = None
+
+      val jsonToken =
+        json"""{
+              "access_token": $accessTokenValue,
+              "refresh_token": $refreshToken,
+              "expires_in": $expiresIn,
+              "user_name": $userName,
+              "domain": $domain,
+              "user_details": {
+                  "username": $userName,
+                  "name": $name,
+                  "forename": $forename,
+                  "surname": $surname,
+                  "mail": $mail,
+                  "cn": $name,
+                  "sn": $surname,
+                  "given_name": $forename
+              },
+              "roles": $roles,
+              "scope": $scope,
+              "security_level": $securityLevel,
+              "user_id": $userId,
+              "token_type": $tokenType
+          }"""
+
+      jsonToken.as[RefreshTokenResponse] shouldBe Right(
+        RefreshTokenResponse(
           accessToken,
           refreshToken,
           expiresIn.seconds,


### PR DESCRIPTION
Removes `circe-generic` and `circe-generic-extras` as described in issue https://github.com/ocadotechnology/sttp-oauth2/issues/3.

I believe it also solves https://github.com/ocadotechnology/sttp-oauth2/issues/5, since `Configuration` is no longer needed, and the remaining `Decoder[FiniteDuration]` occurences have been replaced by an import.