### PR TITLE
Add Accept header when converting auth code to user

### DIFF
--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AuthorizationCode.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AuthorizationCode.scala
@@ -9,6 +9,7 @@ import sttp.monad.MonadError
 import sttp.monad.syntax._
 
 import AuthorizationCodeProvider.Config
+import sttp.model.HeaderNames
 
 object AuthorizationCode {
 
@@ -50,6 +51,7 @@ object AuthorizationCode {
           .post(tokenUri)
           .body(tokenRequestParams(authCode, redirectUri, clientId, clientSecret.value))
           .response(asString)
+          .header(HeaderNames.Accept, "application/json")
       }
       .map(_.body.leftMap(new RuntimeException(_)).flatMap(decode[Oauth2TokenResponse]).toTry)
       .flatMap(backend.responseMonad.fromTry)


### PR DESCRIPTION
Some OAuth2 providers like Github [require explicit `Accept` header](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response), otherwise the response is not formatted in JSON. Currently we only accept JSON responses, so it's a sane default. 