### PR TITLE
RFC7662 compliant transport types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,11 +78,11 @@ val testDependencies = Seq(
 
 val mimaSettings =
   mimaPreviousArtifacts := {
-    // val onlyPatchChanged = previousStableVersion.value.flatMap(CrossVersion.partialVersion) == CrossVersion.partialVersion(version.value)
-    // if (onlyPatchChanged)
-    //   previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet
-    // else
-    Set.empty
+    val onlyPatchChanged = previousStableVersion.value.flatMap(CrossVersion.partialVersion) == CrossVersion.partialVersion(version.value)
+    if (onlyPatchChanged)
+      previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet
+    else
+      Set.empty
   }
 
 lazy val oauth2 = project.settings(

--- a/build.sbt
+++ b/build.sbt
@@ -78,11 +78,11 @@ val testDependencies = Seq(
 
 val mimaSettings =
   mimaPreviousArtifacts := {
-    val onlyPatchChanged = previousStableVersion.value.flatMap(CrossVersion.partialVersion) == CrossVersion.partialVersion(version.value)
-    if (onlyPatchChanged)
-      previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet
-    else
-      Set.empty
+    // val onlyPatchChanged = previousStableVersion.value.flatMap(CrossVersion.partialVersion) == CrossVersion.partialVersion(version.value)
+    // if (onlyPatchChanged)
+    //   previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet
+    // else
+    Set.empty
   }
 
 lazy val oauth2 = project.settings(

--- a/oauth2-backend-cats/src/test/scala/com/ocadotechnology/sttp/oauth2/backend/SttpOauth2ClientCredentialsCatsBackendSpec.scala
+++ b/oauth2-backend-cats/src/test/scala/com/ocadotechnology/sttp/oauth2/backend/SttpOauth2ClientCredentialsCatsBackendSpec.scala
@@ -39,7 +39,7 @@ class SttpOauth2ClientCredentialsCatsBackendSpec extends AsyncWordSpec with Matc
         implicit val mockBackend: SttpBackendStub[IO, Any] = AsyncHttpClientCatsBackend
           .stub[IO]
           .whenTokenIsRequested()
-          .thenRespond(Right(AccessTokenResponse(accessToken, "domain", 100.seconds, scope)))
+          .thenRespond(Right(AccessTokenResponse(accessToken, Some("domain"), 100.seconds, scope)))
           .whenTestAppIsRequestedWithToken(accessToken)
           .thenRespondOk()
 
@@ -57,7 +57,7 @@ class SttpOauth2ClientCredentialsCatsBackendSpec extends AsyncWordSpec with Matc
           AsyncHttpClientCatsBackend
             .stub[IO]
             .whenTokenIsRequested()
-            .thenRespond(Right(AccessTokenResponse(accessToken, "domain", 100.seconds, scope)))
+            .thenRespond(Right(AccessTokenResponse(accessToken, Some("domain"), 100.seconds, scope)))
             .whenTestAppIsRequestedWithToken(accessToken)
             .thenRespondOk()
         )
@@ -82,7 +82,7 @@ class SttpOauth2ClientCredentialsCatsBackendSpec extends AsyncWordSpec with Matc
           AsyncHttpClientCatsBackend
             .stub[IO]
             .whenTokenIsRequested()
-            .thenRespondF(IO.sleep(200.millis).as(Response.ok(Right(AccessTokenResponse(accessToken, "domain", 100.seconds, scope)))))
+            .thenRespondF(IO.sleep(200.millis).as(Response.ok(Right(AccessTokenResponse(accessToken, Some("domain"), 100.seconds, scope)))))
             .whenTestAppIsRequestedWithToken(accessToken)
             .thenRespondOk()
         )
@@ -108,8 +108,8 @@ class SttpOauth2ClientCredentialsCatsBackendSpec extends AsyncWordSpec with Matc
             .stub[IO]
             .whenTokenIsRequested()
             .thenRespondCyclic(
-              Right(AccessTokenResponse(accessToken1, "domain", 100.millis, scope)),
-              Right(AccessTokenResponse(accessToken2, "domain", 100.millis, scope))
+              Right(AccessTokenResponse(accessToken1, Some("domain"), 100.millis, scope)),
+              Right(AccessTokenResponse(accessToken2, Some("domain"), 100.millis, scope))
             )
             .whenTestAppIsRequestedWithToken(accessToken1)
             .thenRespond("body1")

--- a/oauth2-backend-future/src/test/scala/com/ocadotechnology/sttp/oauth2/backend/SttpOauth2ClientCredentialsFutureBackendSpec.scala
+++ b/oauth2-backend-future/src/test/scala/com/ocadotechnology/sttp/oauth2/backend/SttpOauth2ClientCredentialsFutureBackendSpec.scala
@@ -35,7 +35,7 @@ class SttpOauth2ClientCredentialsFutureBackendSpec extends AsyncWordSpec with Ma
         implicit val mockBackend: SttpBackendStub[Future, Any] = AsyncHttpClientFutureBackend
           .stub
           .whenTokenIsRequested()
-          .thenRespond(Right(AccessTokenResponse(accessToken, "domain", 100.seconds, scope)))
+          .thenRespond(Right(AccessTokenResponse(accessToken, Some("domain"), 100.seconds, scope)))
           .whenTestAppIsRequestedWithToken(accessToken)
           .thenRespondOk()
 
@@ -52,7 +52,7 @@ class SttpOauth2ClientCredentialsFutureBackendSpec extends AsyncWordSpec with Ma
           AsyncHttpClientFutureBackend
             .stub
             .whenTokenIsRequested()
-            .thenRespond(Right(AccessTokenResponse(accessToken, "domain", 100.seconds, scope)))
+            .thenRespond(Right(AccessTokenResponse(accessToken, Some("domain"), 100.seconds, scope)))
             .whenTestAppIsRequestedWithToken(accessToken)
             .thenRespondOk()
         )
@@ -78,7 +78,7 @@ class SttpOauth2ClientCredentialsFutureBackendSpec extends AsyncWordSpec with Ma
           AsyncHttpClientFutureBackend
             .stub
             .whenTokenIsRequested()
-            .thenRespondF(Future(Thread.sleep(200)).as(Response.ok(Right(AccessTokenResponse(accessToken, "domain", 100.seconds, scope)))))
+            .thenRespondF(Future(Thread.sleep(200)).as(Response.ok(Right(AccessTokenResponse(accessToken, Some("domain"), 100.seconds, scope)))))
             .whenTestAppIsRequestedWithToken(accessToken)
             .thenRespondOk()
         )
@@ -105,8 +105,8 @@ class SttpOauth2ClientCredentialsFutureBackendSpec extends AsyncWordSpec with Ma
             .stub
             .whenTokenIsRequested()
             .thenRespondCyclic(
-              Right(AccessTokenResponse(accessToken1, "domain", 100.millis, scope)),
-              Right(AccessTokenResponse(accessToken2, "domain", 100.millis, scope))
+              Right(AccessTokenResponse(accessToken1, Some("domain"), 100.millis, scope)),
+              Right(AccessTokenResponse(accessToken2, Some("domain"), 100.millis, scope))
             )
             .whenTestAppIsRequestedWithToken(accessToken1)
             .thenRespond("body1")

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsToken.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsToken.scala
@@ -23,7 +23,7 @@ object ClientCredentialsToken {
 
   final case class AccessTokenResponse(
     accessToken: Secret[String],
-    domain: String,
+    domain: Option[String],
     expiresIn: FiniteDuration,
     scope: Scope
   )

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
@@ -41,6 +41,8 @@ object Introspection {
 
     private implicit val instantDecoder: Decoder[Instant] = Decoder.decodeLong.map(Instant.ofEpochSecond)
 
+    // private implicit val audDecoder: Decoder[Seq[String]] = Decoder.decodeString.map(Seq(_)).or(Decoder.decodeSeq[String])
+
     implicit val decoder: Decoder[TokenIntrospectionResponse] =
       Decoder.forProduct12(
         "active",

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
@@ -20,14 +20,21 @@ object Introspection {
   val response: ResponseAs[Response, Any] =
     common.responseWithCommonError[TokenIntrospectionResponse]
 
+  // Defined by https://datatracker.ietf.org/doc/html/rfc7662#section-2.2 with some extra fields
   final case class TokenIntrospectionResponse(
-    clientId: String,
-    domain: String,
-    exp: Instant,
     active: Boolean,
-    authorities: List[String],
-    scope: Scope,
-    tokenType: String
+    clientId: Option[String] = None,
+    domain: Option[String] = None,
+    exp: Option[Instant] = None,
+    iat: Option[Instant] = None,
+    nbf: Option[Instant] = None,
+    authorities: Option[List[String]] = None,
+    scope: Option[Scope] = None,
+    tokenType: Option[String] = None,
+    sub: Option[String] = None,
+    iss: Option[String] = None,
+    jti: Option[String] = None
+    // aud is missing, not sure how to encode String or Seq[String] at the moment
   )
 
   object TokenIntrospectionResponse {
@@ -35,14 +42,19 @@ object Introspection {
     private implicit val instantDecoder: Decoder[Instant] = Decoder.decodeLong.map(Instant.ofEpochSecond)
 
     implicit val decoder: Decoder[TokenIntrospectionResponse] =
-      Decoder.forProduct7(
+      Decoder.forProduct12(
+        "active",
         "client_id",
         "domain",
         "exp",
-        "active",
+        "iat",
+        "nbf",
         "authorities",
         "scope",
-        "token_type"
+        "token_type",
+        "sub",
+        "iss",
+        "jti"
       )(TokenIntrospectionResponse.apply)
 
   }

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsAccessTokenResponseDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsAccessTokenResponseDeserializationSpec.scala
@@ -16,7 +16,7 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
       // language=JSON
       json"""{
             "access_token": "TAeJwlzT",
-            "domain": "zoo",
+            "domain": "mock",
             "expires_in": 2399,
             "scope": "secondapp",
             "token_type": "Bearer"
@@ -26,7 +26,7 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
     response shouldBe Right(
       ClientCredentialsToken.AccessTokenResponse(
         accessToken = Secret("TAeJwlzT"),
-        domain = Some("zoo"),
+        domain = Some("mock"),
         expiresIn = 2399.seconds,
         scope = Scope.refine("secondapp")
       )
@@ -38,7 +38,7 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
       // language=JSON
       json"""{
             "access_token": "TAeJwlzT",
-            "domain": "zoo",
+            "domain": "mock",
             "expires_in": 2399,
             "scope": "",
             "token_type": "Bearer"
@@ -52,7 +52,7 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
       // language=JSON
       json"""{
             "access_token": "TAeJwlzT",
-            "domain": "zoo",
+            "domain": "mock",
             "expires_in": 2399,
             "scope": " ",
             "token_type": "Bearer"
@@ -66,7 +66,7 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
       // language=JSON
       json"""{
             "access_token": "TAeJwlzT",
-            "domain": "zoo",
+            "domain": "mock",
             "expires_in": 2399,
             "scope": "scope1 scope2",
             "token_type": "Bearer"
@@ -80,7 +80,7 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
       // language=JSON
       json"""{
             "access_token": "TAeJwlzT",
-            "domain": "zoo",
+            "domain": "mock",
             "expires_in": 2399,
             "scope": "secondapp",
             "token_type": "BearerToken"

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsAccessTokenResponseDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsAccessTokenResponseDeserializationSpec.scala
@@ -26,7 +26,7 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
     response shouldBe Right(
       ClientCredentialsToken.AccessTokenResponse(
         accessToken = Secret("TAeJwlzT"),
-        domain = "zoo",
+        domain = Some("zoo"),
         expiresIn = 2399.seconds,
         scope = Scope.refine("secondapp")
       )

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
@@ -32,7 +32,7 @@ class ClientCredentialsTokenDeserializationSpec extends AnyFlatSpec with Matcher
       Right(
         ClientCredentialsToken.AccessTokenResponse(
           accessToken = Secret("TAeJwlzT"),
-          domain = "zoo",
+          domain = Some("zoo"),
           expiresIn = 2399.seconds,
           scope = Scope.refine("cfc.second-app_scope")
         )

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
@@ -20,7 +20,7 @@ class ClientCredentialsTokenDeserializationSpec extends AnyFlatSpec with Matcher
       // language=JSON
       json"""{
             "access_token": "TAeJwlzT",
-            "domain": "zoo",
+            "domain": "mock",
             "expires_in": 2399,
             "panda_session_id": "ac097e1f-f927-41df-a776-d824f538351c",
             "scope": "cfc.second-app_scope",
@@ -32,7 +32,7 @@ class ClientCredentialsTokenDeserializationSpec extends AnyFlatSpec with Matcher
       Right(
         ClientCredentialsToken.AccessTokenResponse(
           accessToken = Secret("TAeJwlzT"),
-          domain = Some("zoo"),
+          domain = Some("mock"),
           expiresIn = 2399.seconds,
           scope = Scope.refine("cfc.second-app_scope")
         )
@@ -45,7 +45,7 @@ class ClientCredentialsTokenDeserializationSpec extends AnyFlatSpec with Matcher
       // language=JSON
       json"""{
             "access_token": "TAeJwlzT",
-            "domain": "zoo",
+            "domain": "mock",
             "expires_in": 2399,
             "panda_session_id": "ac097e1f-f927-41df-a776-d824f538351c",
             "scope": "secondapp",

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/IntrospectionSerializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/IntrospectionSerializationSpec.scala
@@ -13,7 +13,7 @@ class IntrospectionSerializationSpec extends AnyWordSpec with Matchers with Opti
   "Token" should {
     "deserialize token introspection response" in {
       val clientId = "Client ID"
-      val domain = "zoo"
+      val domain = "mock"
       val exp = Instant.EPOCH
       val active = false
       val authorities = List("aaa", "bbb")

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/IntrospectionSerializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/IntrospectionSerializationSpec.scala
@@ -19,6 +19,7 @@ class IntrospectionSerializationSpec extends AnyWordSpec with Matchers with Opti
       val authorities = List("aaa", "bbb")
       val scope = "cfc.first-app_scope"
       val tokenType = "Bearer"
+      val audience = "Aud1"
 
       val json = json"""{
             "client_id": $clientId,
@@ -27,7 +28,8 @@ class IntrospectionSerializationSpec extends AnyWordSpec with Matchers with Opti
             "active": $active,
             "authorities": $authorities,
             "scope": $scope,
-            "token_type": $tokenType
+            "token_type": $tokenType,
+            "aud": $audience
           }"""
 
       json.as[TokenIntrospectionResponse] shouldBe Right(
@@ -38,7 +40,8 @@ class IntrospectionSerializationSpec extends AnyWordSpec with Matchers with Opti
           exp= Some(exp),
           authorities = Some(authorities),
           scope = Some(Scope.of(scope).value),
-          tokenType = Some(tokenType)
+          tokenType = Some(tokenType),
+          aud = Some(Introspection.StringAudience(audience))
         )
       )
 

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/IntrospectionSerializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/IntrospectionSerializationSpec.scala
@@ -31,7 +31,15 @@ class IntrospectionSerializationSpec extends AnyWordSpec with Matchers with Opti
           }"""
 
       json.as[TokenIntrospectionResponse] shouldBe Right(
-        TokenIntrospectionResponse(clientId, domain, exp, active, authorities, Scope.of(scope).value, tokenType)
+        TokenIntrospectionResponse(
+          active = active,
+          clientId = Some(clientId),
+          domain = Some(domain),
+          exp= Some(exp),
+          authorities = Some(authorities),
+          scope = Some(Scope.of(scope).value),
+          tokenType = Some(tokenType)
+        )
       )
 
     }


### PR DESCRIPTION
This PR aims to make transport types for token introspection and access token response compatible with [RFC7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2). All non-standard fields are made optional. 

Resolves https://github.com/ocadotechnology/sttp-oauth2/issues/112 