### PR TITLE
Improved exceptions

### DIFF
--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsProvider.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsProvider.scala
@@ -46,13 +46,13 @@ object ClientCredentialsProvider {
       override def requestToken(scope: Scope): F[ClientCredentialsToken.AccessTokenResponse] =
         ClientCredentials
           .requestToken(tokenUrl, clientId, clientSecret, scope)(backend)
-          .map(_.leftMap(OAuth2Exception).toTry)
+          .map(_.leftMap(OAuth2Exception(_)).toTry)
           .flatMap(backend.responseMonad.fromTry)
 
       override def introspect(token: Secret[String]): F[Introspection.TokenIntrospectionResponse] =
         ClientCredentials
           .introspectToken(tokenIntrospectionUrl, clientId, clientSecret, token)(backend)
-          .map(_.leftMap(OAuth2Exception).toTry)
+          .map(_.leftMap(OAuth2Exception(_)).toTry)
           .flatMap(backend.responseMonad.fromTry)
 
     }

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/PasswordGrantProvider.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/PasswordGrantProvider.scala
@@ -23,7 +23,7 @@ object PasswordGrantProvider {
   )(
     implicit backend: SttpBackend[F, Any]
   ): PasswordGrantProvider[F] = { (user: User, scope: Scope) =>
-    PasswordGrant.requestToken(tokenUrl, user, clientId, clientSecret, scope)(backend).map(_.leftMap(OAuth2Exception)).rethrow
+    PasswordGrant.requestToken(tokenUrl, user, clientId, clientSecret, scope)(backend).map(_.leftMap(OAuth2Exception(_))).rethrow
   }
 
 }


### PR DESCRIPTION
Right now when some exception is thrown it gets logged in such form:
```
com.ocadotechnology.sttp.oauth2.common$OAuth2Exception: null
```

without any details or cause.

The reason is that Exception does not fill the Throwable fields like message or cause.

I've created some proposal, which I'm not 100% happy with though (especially fact how the cause is calculated with pattern matching), but will post is as a beginning for a wider discussion.