### PR TITLE
Fixed response decoder

### DIFF
--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
@@ -30,7 +30,7 @@ object Introspection {
     sub: Option[String] = None,
     iss: Option[String] = None,
     jti: Option[String] = None,
-    aud: Option[Audience]
+    aud: Option[Audience] = None
   )
 
   object TokenIntrospectionResponse {

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
@@ -1,6 +1,5 @@
 package com.ocadotechnology.sttp.oauth2
 
-import com.ocadotechnology.sttp.oauth2.common.Error.OAuth2Error
 import com.ocadotechnology.sttp.oauth2.common._
 import io.circe.Codec
 import io.circe.Decoder
@@ -13,12 +12,6 @@ import java.time.Instant
 object Introspection {
 
   type Response = Either[common.Error, Introspection.TokenIntrospectionResponse]
-
-  private implicit val bearerTokenResponseDecoder: Decoder[Either[OAuth2Error, TokenIntrospectionResponse]] =
-    circe.eitherOrFirstError[TokenIntrospectionResponse, OAuth2Error](
-      Decoder[TokenIntrospectionResponse],
-      Decoder[OAuth2Error]
-    )
 
   val response: ResponseAs[Response, Any] =
     common.responseWithCommonError[TokenIntrospectionResponse]

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/OAuth2Token.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/OAuth2Token.scala
@@ -1,20 +1,12 @@
 package com.ocadotechnology.sttp.oauth2
 
 import com.ocadotechnology.sttp.oauth2.common.Error
-import io.circe.Decoder
 import sttp.client3.ResponseAs
-import com.ocadotechnology.sttp.oauth2.common.Error.OAuth2Error
 
 object OAuth2Token {
 
   // TODO: should be changed to Response[A] and allow custom responses, like in AuthorizationCodeGrant
   type Response = Either[Error, ExtendedOAuth2TokenResponse]
-
-  private implicit val bearerTokenResponseDecoder: Decoder[Either[OAuth2Error, ExtendedOAuth2TokenResponse]] =
-    circe.eitherOrFirstError[ExtendedOAuth2TokenResponse, OAuth2Error](
-      Decoder[ExtendedOAuth2TokenResponse],
-      Decoder[OAuth2Error]
-    )
 
   val response: ResponseAs[Response, Any] =
     common.responseWithCommonError[ExtendedOAuth2TokenResponse]

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/common.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/common.scala
@@ -13,11 +13,13 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.Validate
 import eu.timepit.refined.internal.RefineMPartiallyApplied
 import io.circe.Decoder
+import io.circe.parser.decode
 import sttp.client3.ResponseAs
 import sttp.client3.circe.asJson
 import sttp.model.StatusCode
 import eu.timepit.refined.string.Url
 import sttp.model.Uri
+import sttp.client3.HttpError
 
 object common {
   final case class ValidScope()
@@ -90,11 +92,13 @@ object common {
 
   }
 
-  private[oauth2] def responseWithCommonError[A](implicit decoder: Decoder[Either[OAuth2Error, A]]): ResponseAs[Either[Error, A], Any] =
-    asJson[Either[OAuth2Error, A]].mapWithMetadata { case (either, meta) =>
+  private[oauth2] def responseWithCommonError[A](implicit decoder: Decoder[A]): ResponseAs[Either[Error, A], Any] =
+    asJson[A].mapWithMetadata { case (either, meta) =>
       either match {
-        case Left(sttpError) => Left(Error.HttpClientError(meta.code, sttpError))
-        case Right(value)    => value
+        case Left(HttpError(response, statusCode)) if statusCode.isClientError =>
+          decode[OAuth2Error](response).fold(error => Error.HttpClientError(statusCode, error).asLeft[A], _.asLeft[A])
+        case Left(sttpError)                                                   => Left(Error.HttpClientError(meta.code, sttpError))
+        case Right(value)                                                      => value.asRight[Error]
       }
     }
 

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsSpec.scala
@@ -1,0 +1,170 @@
+package com.ocadotechnology.sttp.oauth2
+
+import com.ocadotechnology.sttp.oauth2.common.Scope
+import com.ocadotechnology.sttp.oauth2.common.Error
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.model.Uri
+import sttp.client3.testing._
+import sttp.monad.TryMonad
+import scala.util.Try
+import eu.timepit.refined.types.string.NonEmptyString
+import eu.timepit.refined.auto._
+import org.scalatest.TryValues
+import org.scalatest.EitherValues
+import sttp.model.StatusCode
+import sttp.model.Method
+import sttp.client3.Request
+
+import scala.concurrent.duration._
+
+class ClientCredentialsSpec extends AnyWordSpec with Matchers with TryValues with EitherValues {
+
+  val baseUri = Uri.unsafeParse("https://sso.example.com/")
+  val tokenUri = baseUri.withPath("token")
+  val tokenIntrospectUri = baseUri.withPath("token/introspect")
+  val clientSecret = Secret("secret")
+  val clientId: NonEmptyString = "client-id"
+  val scope: Scope = "scope"
+  val token = Secret("AX74aXyT")
+
+  val oauth2Errors = List(
+    ("invalid_client", "Client is missing or invalid.", StatusCode.Unauthorized, Error.OAuth2ErrorResponse.InvalidClient),
+    ("invalid_request", "Unsupported parameter.", StatusCode.BadRequest, Error.OAuth2ErrorResponse.InvalidRequest),
+    ("invalid_grant", "Grant is invalid.", StatusCode.BadRequest, Error.OAuth2ErrorResponse.InvalidGrant),
+    (
+      "unauthorized_client",
+      "Client is unaothorized for this grant.",
+      StatusCode.BadRequest,
+      Error.OAuth2ErrorResponse.UnauthorizedClient
+    ),
+    ("unsupported_grant_type", "Grant is unsupported.", StatusCode.BadRequest, Error.OAuth2ErrorResponse.UnsupportedGrantType),
+    ("invalid_scope", "Scope is invalid.", StatusCode.BadRequest, Error.OAuth2ErrorResponse.InvalidScope)
+  )
+
+  "ClientCredentials.requestToken" should {
+
+    val requestToken = ClientCredentials.requestToken[Try](tokenUri, clientId, clientSecret, scope)(_)
+
+    "successfully request token" in {
+      val testingBackend = SttpBackendStub(TryMonad)
+        .whenRequestMatches(validTokenRequest)
+        .thenRespond(
+          """{
+            "access_token": "TAeJwlzT",
+            "domain": "mock",
+            "expires_in": 2399,
+            "scope": "secondapp",
+            "token_type": "Bearer"
+        }""",
+          StatusCode.Ok
+        )
+
+      requestToken(testingBackend).success.value.value shouldBe ClientCredentialsToken.AccessTokenResponse(
+        accessToken = Secret("TAeJwlzT"),
+        domain = Some("mock"),
+        expiresIn = 2399.seconds,
+        scope = Scope.refine("secondapp")
+      )
+
+    }
+
+    oauth2Errors.foreach { case (errorKey, errorDescription, statusCode, error) =>
+      s"support $errorKey OAuth2 error" in {
+
+        val testingBackend = SttpBackendStub(TryMonad)
+          .whenRequestMatches(validTokenRequest)
+          .thenRespond(
+            s"""
+            {
+            "error":"$errorKey",
+            "error_description":"$errorDescription"
+            }
+            """,
+            statusCode
+          )
+
+        requestToken(testingBackend).success.value.left.value shouldBe Error.OAuth2ErrorResponse(error, errorDescription)
+      }
+    }
+
+    "fail on unknown error" in {
+
+      val testingBackend = SttpBackendStub(TryMonad)
+        .whenRequestMatches(validTokenRequest)
+        .thenRespond("""Unknown error""", StatusCode.InternalServerError)
+
+      requestToken(testingBackend).success.value.left.value shouldBe a[Error.HttpClientError]
+    }
+
+    def validTokenRequest(request: Request[_, _]): Boolean =
+      request.method == Method.POST &&
+        request.uri == tokenUri &&
+        request.forceBodyAsString == "grant_type=client_credentials&" +
+        s"client_id=${clientId.value}&" +
+        s"client_secret=${clientSecret.value}&" +
+        s"scope=${scope.value}"
+  }
+
+  "ClientCredentials.introspectToken" should {
+
+    val introspectToken = ClientCredentials.introspectToken[Try](tokenIntrospectUri, clientId, clientSecret, token)(_)
+
+    "successfully introspect token" in {
+      val testingBackend = SttpBackendStub(TryMonad)
+        .whenRequestMatches(validIntrospectRequest)
+        .thenRespond(
+          s"""{
+            "client_id": "$clientId",
+            "active": true,
+            "scope": "$scope"
+          }""",
+          StatusCode.Ok
+        )
+
+      introspectToken(testingBackend).success.value.value shouldBe Introspection.TokenIntrospectionResponse(
+        active = true,
+        clientId = Some(clientId.value),
+        scope = Some(scope)
+      )
+
+    }
+
+    oauth2Errors.foreach { case (errorKey, errorDescription, statusCode, error) =>
+      s"support $errorKey OAuth2 error" in {
+
+        val testingBackend = SttpBackendStub(TryMonad)
+          .whenRequestMatches(validIntrospectRequest)
+          .thenRespond(
+            s"""
+            {
+            "error":"$errorKey",
+            "error_description":"$errorDescription"
+            }
+            """,
+            statusCode
+          )
+
+        introspectToken(testingBackend).success.value.left.value shouldBe Error.OAuth2ErrorResponse(error, errorDescription)
+      }
+    }
+
+    "fail on unknown error" in {
+
+      val testingBackend = SttpBackendStub(TryMonad)
+        .whenRequestMatches(validIntrospectRequest)
+        .thenRespond("""Unknown error""", StatusCode.InternalServerError)
+
+      introspectToken(testingBackend).success.value.left.value shouldBe a[Error.HttpClientError]
+    }
+
+    def validIntrospectRequest(request: Request[_, _]): Boolean =
+      request.method == Method.POST &&
+        request.uri == tokenIntrospectUri &&
+        request.forceBodyAsString == s"client_id=${clientId.value}&" +
+        s"client_secret=${clientSecret.value}&" +
+        s"token=${token.value}"
+  }
+
+}


### PR DESCRIPTION
`asJson[Either[OAuth2Error, A]]` only deserialises `2xx` status codes, so it could never deserialise `4xx` errors, which are usually returned by OAuth providers. 

That's why all such errors ended up to be in `Error.HttpClientError` hierarchy instead of `OAuth2Error`.