### PR TITLE
Optional error description

### DIFF
--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/common.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/common.scala
@@ -52,7 +52,7 @@ object common {
 
     /** Token errors as listed in documentation: https://tools.ietf.org/html/rfc6749#section-5.2
       */
-    final case class OAuth2ErrorResponse(errorType: OAuth2ErrorResponse.OAuth2ErrorResponseType, errorDescription: String)
+    final case class OAuth2ErrorResponse(errorType: OAuth2ErrorResponse.OAuth2ErrorResponseType, errorDescription: Option[String])
       extends Exception(s"$errorType: $errorDescription")
       with OAuth2Error
 
@@ -74,12 +74,12 @@ object common {
 
     }
 
-    final case class UnknownOAuth2Error(error: String, description: String)
+    final case class UnknownOAuth2Error(error: String, description: Option[String])
       extends Exception(s"Unknown OAuth2 error type: $error, description: $description")
       with OAuth2Error
 
     implicit val errorDecoder: Decoder[OAuth2Error] =
-      Decoder.forProduct2[OAuth2Error, String, String]("error", "error_description") { (error, description) =>
+      Decoder.forProduct2[OAuth2Error, String, Option[String]]("error", "error_description") { (error, description) =>
         error match {
           case "invalid_request"        => OAuth2ErrorResponse(InvalidRequest, description)
           case "invalid_client"         => OAuth2ErrorResponse(InvalidClient, description)

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsSpec.scala
@@ -85,7 +85,7 @@ class ClientCredentialsSpec extends AnyWordSpec with Matchers with TryValues wit
             statusCode
           )
 
-        requestToken(testingBackend).success.value.left.value shouldBe Error.OAuth2ErrorResponse(error, errorDescription)
+        requestToken(testingBackend).success.value.left.value shouldBe Error.OAuth2ErrorResponse(error, Some(errorDescription))
       }
     }
 
@@ -146,7 +146,7 @@ class ClientCredentialsSpec extends AnyWordSpec with Matchers with TryValues wit
             statusCode
           )
 
-        introspectToken(testingBackend).success.value.left.value shouldBe Error.OAuth2ErrorResponse(error, errorDescription)
+        introspectToken(testingBackend).success.value.left.value shouldBe Error.OAuth2ErrorResponse(error, Some(errorDescription))
       }
     }
 

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
@@ -65,7 +65,20 @@ class ClientCredentialsTokenDeserializationSpec extends AnyFlatSpec with Matcher
           }"""
 
     json.as[Either[OAuth2Error, AccessTokenResponse]] shouldBe Right(
-      Left(OAuth2ErrorResponse(InvalidClient, "Client is missing or invalid."))
+      Left(OAuth2ErrorResponse(InvalidClient, Some("Client is missing or invalid.")))
+    )
+  }
+
+
+  "JSON with error without optional fields" should "be deserialized to proper type" in {
+    val json =
+      // language=JSON
+      json"""{
+              "error": "invalid_client"
+          }"""
+
+    json.as[Either[OAuth2Error, AccessTokenResponse]] shouldBe Right(
+      Left(OAuth2ErrorResponse(InvalidClient, None))
     )
   }
 

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/OAuth2ErrorDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/OAuth2ErrorDeserializationSpec.scala
@@ -29,7 +29,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Grant type is missing.",
             "error_uri": "https://example.com/errors/invalid_request"
         }""",
-      OAuth2ErrorResponse(InvalidRequest, "Grant type is missing.")
+      OAuth2ErrorResponse(InvalidRequest, Some("Grant type is missing."))
     )
   }
 
@@ -41,7 +41,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Client is missing or invalid.",
             "error_uri": "https://example.com/errors/invalid_client"
         }""",
-      OAuth2ErrorResponse(InvalidClient, "Client is missing or invalid.")
+      OAuth2ErrorResponse(InvalidClient, Some("Client is missing or invalid."))
     )
   }
 
@@ -53,7 +53,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Provided domain cannot be used with given grant type.",
             "error_uri": "https://example.com/errors/invalid_grant"
         }""",
-      OAuth2ErrorResponse(InvalidGrant, "Provided domain cannot be used with given grant type.")
+      OAuth2ErrorResponse(InvalidGrant, Some("Provided domain cannot be used with given grant type."))
     )
   }
 
@@ -65,7 +65,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Client is not allowed to use provided grant type.",
             "error_uri": "https://example.com/errors/unauthorized_client"
         }""",
-      OAuth2ErrorResponse(UnauthorizedClient, "Client is not allowed to use provided grant type.")
+      OAuth2ErrorResponse(UnauthorizedClient, Some("Client is not allowed to use provided grant type."))
     )
   }
 
@@ -77,7 +77,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Requested grant type is invalid.",
             "error_uri": "https://example.com/errors/unsupported_grant_type"
         }""",
-      OAuth2ErrorResponse(UnsupportedGrantType, "Requested grant type is invalid.")
+      OAuth2ErrorResponse(UnsupportedGrantType, Some("Requested grant type is invalid."))
     )
   }
 
@@ -89,7 +89,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Client is not allowed to use requested scope.",
             "error_uri": "https://example.com/errors/invalid_scope"
         }""",
-      OAuth2ErrorResponse(InvalidScope, "Client is not allowed to use requested scope.")
+      OAuth2ErrorResponse(InvalidScope, Some("Client is not allowed to use requested scope."))
     )
   }
 
@@ -101,7 +101,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Invalid access token.",
             "error_uri": "https://example.com/errors/invalid_token"
         }""",
-      UnknownOAuth2Error(error = "invalid_token", "Invalid access token.")
+      UnknownOAuth2Error(error = "invalid_token", Some("Invalid access token."))
     )
   }
 
@@ -113,7 +113,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Access token does not contain requested scope.",
             "error_uri": "https://example.com/errors/insufficient_scope"
         }""",
-      UnknownOAuth2Error(error = "insufficient_scope", "Access token does not contain requested scope.")
+      UnknownOAuth2Error(error = "insufficient_scope", Some("Access token does not contain requested scope."))
     )
   }
 
@@ -125,7 +125,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "I don't know this error type.",
             "error_uri": "https://example.com/errors/unknown_error"
         }""",
-      UnknownOAuth2Error(error = "unknown_error", description = "I don't know this error type.")
+      UnknownOAuth2Error(error = "unknown_error", description = Some("I don't know this error type."))
     )
   }
 


### PR DESCRIPTION
In https://datatracker.ietf.org/doc/html/rfc6749 error description is optional:

```
   error_description
         OPTIONAL.  Human-readable ASCII [USASCII] text providing
         additional information, used to assist the client developer in
         understanding the error that occurred.
         Values for the "error_description" parameter MUST NOT include
         characters outside the set %x20-21 / %x23-5B / %x5D-7E.
```