### PR TITLE
Nicer error message

### DIFF
--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/common.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/common.scala
@@ -53,7 +53,7 @@ object common {
     /** Token errors as listed in documentation: https://tools.ietf.org/html/rfc6749#section-5.2
       */
     final case class OAuth2ErrorResponse(errorType: OAuth2ErrorResponse.OAuth2ErrorResponseType, errorDescription: Option[String])
-      extends Exception(s"$errorType: $errorDescription")
+      extends Exception(errorDescription.fold(s"$errorType")(description => s"$errorType: $description"))
       with OAuth2Error
 
     object OAuth2ErrorResponse {
@@ -74,8 +74,12 @@ object common {
 
     }
 
-    final case class UnknownOAuth2Error(error: String, description: Option[String])
-      extends Exception(s"Unknown OAuth2 error type: $error, description: $description")
+    final case class UnknownOAuth2Error(error: String, errorDescription: Option[String])
+      extends Exception(
+        errorDescription.fold(s"Unknown OAuth2 error type: $error")(description =>
+          s"Unknown OAuth2 error type: $error, description: $description"
+        )
+      )
       with OAuth2Error
 
     implicit val errorDecoder: Decoder[OAuth2Error] =

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
@@ -69,7 +69,6 @@ class ClientCredentialsTokenDeserializationSpec extends AnyFlatSpec with Matcher
     )
   }
 
-
   "JSON with error without optional fields" should "be deserialized to proper type" in {
     val json =
       // language=JSON

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/OAuth2ErrorDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/OAuth2ErrorDeserializationSpec.scala
@@ -125,7 +125,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "I don't know this error type.",
             "error_uri": "https://example.com/errors/unknown_error"
         }""",
-      UnknownOAuth2Error(error = "unknown_error", description = Some("I don't know this error type."))
+      UnknownOAuth2Error(error = "unknown_error", errorDescription = Some("I don't know this error type."))
     )
   }
 


### PR DESCRIPTION
Instead:

```
Caused by: com.ocadotechnology.sttp.oauth2.common$Error$OAuth2ErrorResponse: InvalidClient: Some(Client is missing or invalid.)
```

it will be:

```
Caused by: com.ocadotechnology.sttp.oauth2.common$Error$OAuth2ErrorResponse: InvalidClient: Client is missing or invalid.
```

or 

```
Caused by: com.ocadotechnology.sttp.oauth2.common$Error$OAuth2ErrorResponse: InvalidClient
```
if the description is missing (which is a rare case anway)