### PR TITLE
Refactor errors, introduce type parameter in Error

### DIFF
--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AccessTokenProvider.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AccessTokenProvider.scala
@@ -36,7 +36,7 @@ object AccessTokenProvider {
       override def requestToken(scope: Scope): F[ClientCredentialsToken.AccessTokenResponse] =
         ClientCredentials
           .requestToken(tokenUrl, clientId, clientSecret, scope)(backend)
-          .map(_.leftMap(OAuth2Exception).toTry)
+          .map(_.leftMap(_.toException).toTry)
           .flatMap(backend.responseMonad.fromTry)
 
     }

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsToken.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsToken.scala
@@ -4,19 +4,12 @@ import com.ocadotechnology.sttp.oauth2.common._
 import io.circe.Decoder
 import io.circe.refined._
 import sttp.client3.ResponseAs
-import com.ocadotechnology.sttp.oauth2.common.Error.OAuth2Error
 
 import scala.concurrent.duration.FiniteDuration
 
 object ClientCredentialsToken {
 
-  type Response = Either[Error, ClientCredentialsToken.AccessTokenResponse]
-
-  private[oauth2] implicit val bearerTokenResponseDecoder: Decoder[Either[OAuth2Error, AccessTokenResponse]] =
-    circe.eitherOrFirstError[AccessTokenResponse, OAuth2Error](
-      Decoder[AccessTokenResponse],
-      Decoder[OAuth2Error]
-    )
+  type Response = Either[Error[Throwable], ClientCredentialsToken.AccessTokenResponse]
 
   val response: ResponseAs[Response, Any] =
     common.responseWithCommonError[ClientCredentialsToken.AccessTokenResponse]

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/Introspection.scala
@@ -11,7 +11,7 @@ import java.time.Instant
 
 object Introspection {
 
-  type Response = Either[common.Error, Introspection.TokenIntrospectionResponse]
+  type Response = Either[common.Error[Throwable], Introspection.TokenIntrospectionResponse]
 
   val response: ResponseAs[Response, Any] =
     common.responseWithCommonError[TokenIntrospectionResponse]

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/OAuth2Token.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/OAuth2Token.scala
@@ -6,7 +6,7 @@ import sttp.client3.ResponseAs
 object OAuth2Token {
 
   // TODO: should be changed to Response[A] and allow custom responses, like in AuthorizationCodeGrant
-  type Response = Either[Error, ExtendedOAuth2TokenResponse]
+  type Response = Either[Error[Throwable], ExtendedOAuth2TokenResponse]
 
   val response: ResponseAs[Response, Any] =
     common.responseWithCommonError[ExtendedOAuth2TokenResponse]

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/PasswordGrantProvider.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/PasswordGrantProvider.scala
@@ -23,7 +23,7 @@ object PasswordGrantProvider {
   )(
     backend: SttpBackend[F, Any]
   ): PasswordGrantProvider[F] = { (user: User, scope: Scope) =>
-    PasswordGrant.requestToken(tokenUrl, user, clientId, clientSecret, scope)(backend).map(_.leftMap(OAuth2Exception)).rethrow
+    PasswordGrant.requestToken(tokenUrl, user, clientId, clientSecret, scope)(backend).map(_.leftMap(_.toException)).rethrow
   }
 
 }

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/TokenIntrospection.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/TokenIntrospection.scala
@@ -37,7 +37,7 @@ object TokenIntrospection {
       override def introspect(token: Secret[String]): F[Introspection.TokenIntrospectionResponse] =
         ClientCredentials
           .introspectToken(tokenIntrospectionUrl, clientId, clientSecret, token)(backend)
-          .map(_.leftMap(OAuth2Exception).toTry)
+          .map(_.leftMap(_.toException).toTry)
           .flatMap(backend.responseMonad.fromTry)
 
     }

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/OAuth2ErrorDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/OAuth2ErrorDeserializationSpec.scala
@@ -18,8 +18,10 @@ import io.circe.literal._
 
 class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with EitherValues {
 
-  private def check[A <: OAuth2Error](json: Json, deserialized: A) =
-    json.as[OAuth2Error] shouldBe Right(deserialized)
+  implicit val decoder: io.circe.Decoder[OAuth2Error[Unit]] = common.Error.errorDecoder(())
+
+  private def check[A <: OAuth2Error[Unit]](json: Json, deserialized: A) =
+    json.as[OAuth2Error[Unit]] shouldBe Right(deserialized)
 
   "invalid_request error JSON" should "be deserialized to InvalidRequest" in {
     check(
@@ -29,7 +31,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Grant type is missing.",
             "error_uri": "https://example.com/errors/invalid_request"
         }""",
-      OAuth2ErrorResponse(InvalidRequest, Some("Grant type is missing."))
+      OAuth2ErrorResponse(InvalidRequest, Some("Grant type is missing."), ())
     )
   }
 
@@ -41,7 +43,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Client is missing or invalid.",
             "error_uri": "https://example.com/errors/invalid_client"
         }""",
-      OAuth2ErrorResponse(InvalidClient, Some("Client is missing or invalid."))
+      OAuth2ErrorResponse(InvalidClient, Some("Client is missing or invalid."), ())
     )
   }
 
@@ -53,7 +55,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Provided domain cannot be used with given grant type.",
             "error_uri": "https://example.com/errors/invalid_grant"
         }""",
-      OAuth2ErrorResponse(InvalidGrant, Some("Provided domain cannot be used with given grant type."))
+      OAuth2ErrorResponse(InvalidGrant, Some("Provided domain cannot be used with given grant type."), ())
     )
   }
 
@@ -65,7 +67,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Client is not allowed to use provided grant type.",
             "error_uri": "https://example.com/errors/unauthorized_client"
         }""",
-      OAuth2ErrorResponse(UnauthorizedClient, Some("Client is not allowed to use provided grant type."))
+      OAuth2ErrorResponse(UnauthorizedClient, Some("Client is not allowed to use provided grant type."), ())
     )
   }
 
@@ -77,7 +79,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Requested grant type is invalid.",
             "error_uri": "https://example.com/errors/unsupported_grant_type"
         }""",
-      OAuth2ErrorResponse(UnsupportedGrantType, Some("Requested grant type is invalid."))
+      OAuth2ErrorResponse(UnsupportedGrantType, Some("Requested grant type is invalid."), ())
     )
   }
 
@@ -89,7 +91,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Client is not allowed to use requested scope.",
             "error_uri": "https://example.com/errors/invalid_scope"
         }""",
-      OAuth2ErrorResponse(InvalidScope, Some("Client is not allowed to use requested scope."))
+      OAuth2ErrorResponse(InvalidScope, Some("Client is not allowed to use requested scope."), ())
     )
   }
 
@@ -101,7 +103,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Invalid access token.",
             "error_uri": "https://example.com/errors/invalid_token"
         }""",
-      UnknownOAuth2Error(error = "invalid_token", Some("Invalid access token."))
+      UnknownOAuth2Error(errorString = "invalid_token", Some("Invalid access token."), ())
     )
   }
 
@@ -113,7 +115,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "Access token does not contain requested scope.",
             "error_uri": "https://example.com/errors/insufficient_scope"
         }""",
-      UnknownOAuth2Error(error = "insufficient_scope", Some("Access token does not contain requested scope."))
+      UnknownOAuth2Error(errorString = "insufficient_scope", Some("Access token does not contain requested scope."), ())
     )
   }
 
@@ -125,7 +127,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "error_description": "I don't know this error type.",
             "error_uri": "https://example.com/errors/unknown_error"
         }""",
-      UnknownOAuth2Error(error = "unknown_error", errorDescription = Some("I don't know this error type."))
+      UnknownOAuth2Error(errorString = "unknown_error", errorDescription = Some("I don't know this error type."), ())
     )
   }
 
@@ -137,7 +139,7 @@ class OAuth2ErrorDeserializationSpec extends AnyFlatSpec with Matchers with Eith
             "description": "YOLO"
         }"""
 
-    json.as[OAuth2Error].left.value shouldBe a[DecodingFailure]
+    json.as[OAuth2Error[Unit]].left.value shouldBe a[DecodingFailure]
   }
 
 }


### PR DESCRIPTION
Experiment with another encoding of errors. It wraps cause in type parameter, so for Throwable it will get the whole cause, etc, but Errors won't be in the Throwable hierarchy.

- Error contains type parameter
- Removed inheritance from Throwable
- Introduced conversion toException