### PR TITLE
Made Scope optional for both request and response (#124)

### DIFF
--- a/docs/client-credentials.md
+++ b/docs/client-credentials.md
@@ -12,7 +12,8 @@ description: Client credentials grant documentation
 ```scala
 val accessTokenProvider = AccessTokenProvider[IO](tokenUrl, clientId, clientSecret)(backend)
 val tokenIntrospection = TokenIntrospection[IO](tokenIntrospectionUrl, clientId, clientSecret)(backend)
-  
+val scope: Option[Scope] = Some("scope")
+
 for {
   token <- accessTokenProvider.requestToken(scope) // ask for token
   response <- tokenIntrospection.introspect(token.accessToken) // check if token is valid
@@ -46,7 +47,7 @@ CachingAccessTokenProvider.refCacheInstance[IO](delegate)
 
 
 ```scala
-val scope: Scope = "scope" // backend will use defined scope for all requests
+val scope: Option[Scope] = Some("scope") // backend will use defined scope for all requests
 val backend: SttpBackend[IO, Any] = SttpOauth2ClientCredentialsBackend[IO, Any](tokenUrl, clientId, clientSecret)(scope)(delegateBackend)
 backend.send(request) // this will add header: Authorization: Bearer {token}
 

--- a/oauth2-cache-cats/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/cats/CachingAccessTokenProviderParallelSpec.scala
+++ b/oauth2-cache-cats/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/cats/CachingAccessTokenProviderParallelSpec.scala
@@ -20,7 +20,7 @@ import java.time.Instant
 import scala.concurrent.duration._
 
 class CachingAccessTokenProviderParallelSpec extends AnyWordSpec with Matchers {
-  private val testScope: Scope = "test-scope"
+  private val testScope: Option[Scope] = Some("test-scope")
   private val token = AccessTokenResponse(Secret("secret"), None, 10.seconds, testScope)
 
   private val sleepDuration: FiniteDuration = 1.second
@@ -73,7 +73,7 @@ class CachingAccessTokenProviderParallelSpec extends AnyWordSpec with Matchers {
     for {
       state           <- Ref.of[IO, TestAccessTokenProvider.State](TestAccessTokenProvider.State.empty)
       delegate = TestAccessTokenProvider[IO](state)
-      cache           <- CatsRefExpiringCache[IO, Scope, TokenWithExpirationTime]
+      cache           <- CatsRefExpiringCache[IO, Option[Scope], TokenWithExpirationTime]
       delayingCache = new DelayingCache(cache)
       cachingProvider <- CachingAccessTokenProvider[IO](delegate, delayingCache)
     } yield (delegate, cachingProvider)

--- a/oauth2-cache-cats/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/cats/CachingAccessTokenProviderSpec.scala
+++ b/oauth2-cache-cats/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/cats/CachingAccessTokenProviderSpec.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 class CachingAccessTokenProviderSpec extends AnyWordSpec with Matchers with TestInstances {
   private implicit val ticker: Ticker = Ticker(TestContext())
 
-  private val testScope: Scope = "test-scope"
+  private val testScope: Option[Scope] = Some("test-scope")
   private val token = AccessTokenResponse(Secret("secret"), None, 10.seconds, testScope)
   private val newToken = AccessTokenResponse(Secret("secret2"), None, 20.seconds, testScope)
 
@@ -73,7 +73,7 @@ class CachingAccessTokenProviderSpec extends AnyWordSpec with Matchers with Test
     for {
       state           <- Ref.of[IO, TestAccessTokenProvider.State](TestAccessTokenProvider.State.empty)
       delegate = TestAccessTokenProvider[IO](state)
-      cache           <- CatsRefExpiringCache[IO, Scope, TokenWithExpirationTime]
+      cache           <- CatsRefExpiringCache[IO, Option[Scope], TokenWithExpirationTime]
       cachingProvider <- CachingAccessTokenProvider[IO](delegate, cache)
     } yield (delegate, cachingProvider)
 

--- a/oauth2-cache-cats/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/cats/TestAccessTokenProvider.scala
+++ b/oauth2-cache-cats/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/cats/TestAccessTokenProvider.scala
@@ -10,13 +10,13 @@ import com.ocadotechnology.sttp.oauth2.Secret
 import com.ocadotechnology.sttp.oauth2.common.Scope
 
 trait TestAccessTokenProvider[F[_]] extends AccessTokenProvider[F] {
-  def setToken(scope: Scope, token: ClientCredentialsToken.AccessTokenResponse): F[Unit]
+  def setToken(scope: Option[Scope], token: ClientCredentialsToken.AccessTokenResponse): F[Unit]
 }
 
 object TestAccessTokenProvider {
 
   final case class State(
-    tokens: Map[Scope, ClientCredentialsToken.AccessTokenResponse],
+    tokens: Map[Option[Scope], ClientCredentialsToken.AccessTokenResponse],
     introspections: Map[Secret[String], Introspection.TokenIntrospectionResponse]
   )
 
@@ -26,10 +26,10 @@ object TestAccessTokenProvider {
 
   def apply[F[_]: Functor](ref: Ref[F, State]): TestAccessTokenProvider[F] =
     new TestAccessTokenProvider[F] {
-      override def requestToken(scope: Scope): F[ClientCredentialsToken.AccessTokenResponse] =
+      override def requestToken(scope: Option[Scope]): F[ClientCredentialsToken.AccessTokenResponse] =
         ref.get.map(_.tokens.getOrElse(scope, throw new IllegalArgumentException(s"Unknown $scope")))
 
-      override def setToken(scope: Scope, token: ClientCredentialsToken.AccessTokenResponse): F[Unit] =
+      override def setToken(scope: Option[Scope], token: ClientCredentialsToken.AccessTokenResponse): F[Unit] =
         ref.update(state => state.copy(tokens = state.tokens + (scope -> token)))
     }
 

--- a/oauth2-cache-ce2/src/main/scala/com/ocadotechnology/sttp/oauth2/cache/ce2/CachingAccessTokenProvider.scala
+++ b/oauth2-cache-ce2/src/main/scala/com/ocadotechnology/sttp/oauth2/cache/ce2/CachingAccessTokenProvider.scala
@@ -19,22 +19,22 @@ import scala.concurrent.duration.Duration
 final class CachingAccessTokenProvider[F[_]: Monad: Clock](
   delegate: AccessTokenProvider[F],
   semaphore: Semaphore[F],
-  tokenCache: ExpiringCache[F, Scope, TokenWithExpirationTime]
+  tokenCache: ExpiringCache[F, Option[Scope], TokenWithExpirationTime]
 ) extends AccessTokenProvider[F] {
 
-  override def requestToken(scope: Scope): F[ClientCredentialsToken.AccessTokenResponse] =
+  override def requestToken(scope: Option[Scope]): F[ClientCredentialsToken.AccessTokenResponse] =
     getFromCache(scope)
       .getOrElseF(semaphore.withPermit(acquireToken(scope))) // semaphore prevents concurrent token fetch from external service
 
-  private def acquireToken(scope: Scope) =
+  private def acquireToken(scope: Option[Scope]) =
     getFromCache(scope) // duplicate cache check, to verify if any other thread filled the cache during wait for semaphore permit
       .getOrElseF(fetchAndSaveToken(scope))
 
-  private def getFromCache(scope: Scope) =
+  private def getFromCache(scope: Option[Scope]) =
     (OptionT(tokenCache.get(scope)), OptionT.liftF(Clock[F].instantNow))
       .mapN(_.toAccessTokenResponse(_))
 
-  private def fetchAndSaveToken(scope: Scope) =
+  private def fetchAndSaveToken(scope: Option[Scope]) =
     for {
       token           <- delegate.requestToken(scope)
       tokenWithExpiry <- calculateExpiryInstant(token)
@@ -50,17 +50,17 @@ object CachingAccessTokenProvider {
 
   def apply[F[_]: Concurrent: Clock](
     delegate: AccessTokenProvider[F],
-    tokenCache: ExpiringCache[F, Scope, TokenWithExpirationTime]
+    tokenCache: ExpiringCache[F, Option[Scope], TokenWithExpirationTime]
   ): F[CachingAccessTokenProvider[F]] = Semaphore[F](n = 1).map(new CachingAccessTokenProvider[F](delegate, _, tokenCache))
 
   def refCacheInstance[F[_]: Concurrent: Clock](delegate: AccessTokenProvider[F]): F[CachingAccessTokenProvider[F]] =
-    CatsRefExpiringCache[F, Scope, TokenWithExpirationTime].flatMap(CachingAccessTokenProvider(delegate, _))
+    CatsRefExpiringCache[F, Option[Scope], TokenWithExpirationTime].flatMap(CachingAccessTokenProvider(delegate, _))
 
   final case class TokenWithExpirationTime(
     accessToken: Secret[String],
     domain: Option[String],
     expirationTime: Instant,
-    scope: Scope
+    scope: Option[Scope]
   ) {
 
     def toAccessTokenResponse(now: Instant): ClientCredentialsToken.AccessTokenResponse = {

--- a/oauth2-cache-ce2/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/ce2/CachingAccessTokenProviderParallelSpec.scala
+++ b/oauth2-cache-ce2/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/ce2/CachingAccessTokenProviderParallelSpec.scala
@@ -26,7 +26,7 @@ class CachingAccessTokenProviderParallelSpec extends AnyWordSpec with Matchers {
   implicit lazy val cs: ContextShift[IO] = IO.contextShift(ec)
   implicit val clock: Timer[IO] = IO.timer(ec)
 
-  private val testScope: Scope = "test-scope"
+  private val testScope: Option[Scope] = Some("test-scope")
   private val token = AccessTokenResponse(Secret("secret"), None, 10.seconds, testScope)
 
   private val sleepDuration: FiniteDuration = 1.second
@@ -79,7 +79,7 @@ class CachingAccessTokenProviderParallelSpec extends AnyWordSpec with Matchers {
     for {
       state           <- Ref.of[IO, TestAccessTokenProvider.State](TestAccessTokenProvider.State.empty)
       delegate = TestAccessTokenProvider[IO](state)
-      cache           <- CatsRefExpiringCache[IO, Scope, TokenWithExpirationTime]
+      cache           <- CatsRefExpiringCache[IO, Option[Scope], TokenWithExpirationTime]
       delayingCache = new DelayingCache(cache)
       cachingProvider <- CachingAccessTokenProvider[IO](delegate, delayingCache)
     } yield (delegate, cachingProvider)

--- a/oauth2-cache-ce2/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/ce2/CachingAccessTokenProviderSpec.scala
+++ b/oauth2-cache-ce2/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/ce2/CachingAccessTokenProviderSpec.scala
@@ -22,7 +22,7 @@ class CachingAccessTokenProviderSpec extends AnyWordSpec with Matchers {
   implicit lazy val cs: ContextShift[IO] = IO.contextShift(testContext)
   implicit lazy val ioTimer: Timer[IO] = testContext.timer[IO]
 
-  private val testScope: Scope = "test-scope"
+  private val testScope: Option[Scope] = Some("test-scope")
   private val token = AccessTokenResponse(Secret("secret"), None, 10.seconds, testScope)
   private val newToken = AccessTokenResponse(Secret("secret2"), None, 20.seconds, testScope)
 
@@ -72,7 +72,7 @@ class CachingAccessTokenProviderSpec extends AnyWordSpec with Matchers {
     for {
       state           <- Ref.of[IO, TestAccessTokenProvider.State](TestAccessTokenProvider.State.empty)
       delegate = TestAccessTokenProvider[IO](state)
-      cache           <- CatsRefExpiringCache[IO, Scope, TokenWithExpirationTime]
+      cache           <- CatsRefExpiringCache[IO, Option[Scope], TokenWithExpirationTime]
       cachingProvider <- CachingAccessTokenProvider[IO](delegate, cache)
     } yield (delegate, cachingProvider)
 

--- a/oauth2-cache-ce2/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/ce2/TestAccessTokenProvider.scala
+++ b/oauth2-cache-ce2/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/ce2/TestAccessTokenProvider.scala
@@ -10,13 +10,13 @@ import com.ocadotechnology.sttp.oauth2.common.Scope
 import com.ocadotechnology.sttp.oauth2.AccessTokenProvider
 
 trait TestAccessTokenProvider[F[_]] extends AccessTokenProvider[F] {
-  def setToken(scope: Scope, token: ClientCredentialsToken.AccessTokenResponse): F[Unit]
+  def setToken(scope: Option[Scope], token: ClientCredentialsToken.AccessTokenResponse): F[Unit]
 }
 
 object TestAccessTokenProvider {
 
   final case class State(
-    tokens: Map[Scope, ClientCredentialsToken.AccessTokenResponse],
+    tokens: Map[Option[Scope], ClientCredentialsToken.AccessTokenResponse],
     introspections: Map[Secret[String], Introspection.TokenIntrospectionResponse]
   )
 
@@ -26,10 +26,10 @@ object TestAccessTokenProvider {
 
   def apply[F[_]: Functor](ref: Ref[F, State]): TestAccessTokenProvider[F] =
     new TestAccessTokenProvider[F] {
-      override def requestToken(scope: Scope): F[ClientCredentialsToken.AccessTokenResponse] =
+      override def requestToken(scope: Option[Scope]): F[ClientCredentialsToken.AccessTokenResponse] =
         ref.get.map(_.tokens.getOrElse(scope, throw new IllegalArgumentException(s"Unknown $scope")))
 
-      override def setToken(scope: Scope, token: ClientCredentialsToken.AccessTokenResponse): F[Unit] =
+      override def setToken(scope: Option[Scope], token: ClientCredentialsToken.AccessTokenResponse): F[Unit] =
         ref.update(state => state.copy(tokens = state.tokens + (scope -> token)))
     }
 

--- a/oauth2-cache-future/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/future/FutureCachingAccessTokenProviderSpec.scala
+++ b/oauth2-cache-future/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/future/FutureCachingAccessTokenProviderSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 
 class FutureCachingAccessTokenProviderSpec extends AsyncWordSpec with Matchers {
 
-  private val testScope: Scope = "test-scope"
+  private val testScope: Option[Scope] = Some("test-scope")
   private val someTime = Instant.parse("2021-10-03T10:15:30.00Z")
   private val token = AccessTokenResponse(Secret("secret"), None, 10.seconds, testScope)
   private val newToken = AccessTokenResponse(Secret("secret2"), None, 20.seconds, testScope)
@@ -63,7 +63,7 @@ class FutureCachingAccessTokenProviderSpec extends AsyncWordSpec with Matchers {
   def runTest(test: ((TestAccessTokenProvider, AccessTokenProvider[Future], TestTimeProvider)) => Future[Assertion]): Future[Assertion] = {
     val delegate = TestAccessTokenProvider.instance()
     val timeProvider = TestTimeProvider.instance(someTime)
-    val cache = MonixFutureCache[Scope, TokenWithExpirationTime](timeProvider)
+    val cache = MonixFutureCache[Option[Scope], TokenWithExpirationTime](timeProvider)
     val cacheProvider = FutureCachingAccessTokenProvider(delegate, cache, timeProvider)
 
     test((delegate, cacheProvider, timeProvider))

--- a/oauth2-cache-future/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/future/TestAccessTokenProvider.scala
+++ b/oauth2-cache-future/src/test/scala/com/ocadotechnology/sttp/oauth2/cache/future/TestAccessTokenProvider.scala
@@ -7,22 +7,22 @@ import scala.concurrent.Future
 import monix.execution.atomic.AtomicAny
 import scala.concurrent.ExecutionContext
 
-class TestAccessTokenProvider private (initial: Map[Scope, ClientCredentialsToken.AccessTokenResponse])(implicit ec: ExecutionContext)
+class TestAccessTokenProvider private (initial: Map[Option[Scope], ClientCredentialsToken.AccessTokenResponse])(implicit ec: ExecutionContext)
   extends AccessTokenProvider[Future] {
 
   private val ref = AtomicAny(initial)
 
-  def setToken(scope: Scope, token: ClientCredentialsToken.AccessTokenResponse): Future[Unit] =
+  def setToken(scope: Option[Scope], token: ClientCredentialsToken.AccessTokenResponse): Future[Unit] =
     Future.successful(ref.transform(_ + (scope -> token)))
 
-  def requestToken(scope: Scope): Future[ClientCredentialsToken.AccessTokenResponse] =
+  def requestToken(scope: Option[Scope]): Future[ClientCredentialsToken.AccessTokenResponse] =
     Future(ref.get().getOrElse(scope, throw new IllegalArgumentException(s"Unknown $scope")))
 }
 
 object TestAccessTokenProvider {
 
   def instance(
-    initial: Map[Scope, ClientCredentialsToken.AccessTokenResponse] = Map.empty
+    initial: Map[Option[Scope], ClientCredentialsToken.AccessTokenResponse] = Map.empty
   )(
     implicit ec: ExecutionContext
   ): TestAccessTokenProvider = new TestAccessTokenProvider(initial)

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AccessTokenProvider.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AccessTokenProvider.scala
@@ -14,7 +14,7 @@ trait AccessTokenProvider[F[_]] {
     *
     * The scope is the scope of the application we want to communicate with.
     */
-  def requestToken(scope: Scope): F[ClientCredentialsToken.AccessTokenResponse]
+  def requestToken(scope: Option[Scope]): F[ClientCredentialsToken.AccessTokenResponse]
 }
 
 object AccessTokenProvider {
@@ -33,7 +33,7 @@ object AccessTokenProvider {
     new AccessTokenProvider[F] {
       implicit val F: MonadError[F] = backend.responseMonad
 
-      override def requestToken(scope: Scope): F[ClientCredentialsToken.AccessTokenResponse] =
+      override def requestToken(scope: Option[Scope]): F[ClientCredentialsToken.AccessTokenResponse] =
         ClientCredentials
           .requestToken(tokenUrl, clientId, clientSecret, scope)(backend)
           .map(_.leftMap(OAuth2Exception).toTry)

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentials.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentials.scala
@@ -19,7 +19,7 @@ object ClientCredentials {
     tokenUri: Uri,
     clientId: NonEmptyString,
     clientSecret: Secret[String],
-    scope: Scope
+    scope: Option[Scope]
   )(
     backend: SttpBackend[F, Any]
   ): F[ClientCredentialsToken.Response] = {
@@ -34,13 +34,12 @@ object ClientCredentials {
       .map(_.body)
   }
 
-  private def requestTokenParams(clientId: NonEmptyString, clientSecret: Secret[String], scope: Scope) =
+  private def requestTokenParams(clientId: NonEmptyString, clientSecret: Secret[String], scope: Option[Scope]) =
     Map(
       "grant_type" -> "client_credentials",
       "client_id" -> clientId.value,
-      "client_secret" -> clientSecret.value,
-      "scope" -> scope.value
-    )
+      "client_secret" -> clientSecret.value
+    ) ++ scope.map(s => Map("scope" -> s.value)).getOrElse(Map.empty)
 
   /** Introspects provided `token` in OAuth2 provider `tokenIntrospectionUri`, using `clientId` and `clientSecret`. Request is performed
     * with provided `backend`.

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsProvider.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsProvider.scala
@@ -30,7 +30,7 @@ object ClientCredentialsProvider {
 
   def apply[F[_]](accessTokenProvider: AccessTokenProvider[F], tokenIntrospection: TokenIntrospection[F]): ClientCredentialsProvider[F] =
     new ClientCredentialsProvider[F] {
-      override def requestToken(scope: Scope): F[ClientCredentialsToken.AccessTokenResponse] =
+      override def requestToken(scope: Option[Scope]): F[ClientCredentialsToken.AccessTokenResponse] =
         accessTokenProvider.requestToken(scope)
 
       override def introspect(token: Secret[String]): F[Introspection.TokenIntrospectionResponse] =

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsToken.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsToken.scala
@@ -25,7 +25,7 @@ object ClientCredentialsToken {
     accessToken: Secret[String],
     domain: Option[String],
     expiresIn: FiniteDuration,
-    scope: Scope
+    scope: Option[Scope]
   )
 
   object AccessTokenResponse {

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/SttpOauth2ClientCredentialsBackend.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/SttpOauth2ClientCredentialsBackend.scala
@@ -13,7 +13,7 @@ import sttp.model.Uri
 final class SttpOauth2ClientCredentialsBackend[F[_]: Monad, P] private (
   delegate: SttpBackend[F, P],
   accessTokenProvider: AccessTokenProvider[F],
-  scope: common.Scope
+  scope: Option[common.Scope]
 ) extends DelegateSttpBackend(delegate) {
 
   override def send[T, R >: P with Effect[F]](request: Request[T, R]): F[Response[T]] = for {
@@ -30,7 +30,7 @@ object SttpOauth2ClientCredentialsBackend {
     clientId: NonEmptyString,
     clientSecret: Secret[String]
   )(
-    scope: Scope
+    scope: Option[Scope]
   )(
     backend: SttpBackend[F, P]
   ): SttpOauth2ClientCredentialsBackend[F, P] = {
@@ -41,7 +41,7 @@ object SttpOauth2ClientCredentialsBackend {
   def apply[F[_]: Monad, P](
     accessTokenProvider: AccessTokenProvider[F]
   )(
-    scope: Scope
+    scope: Option[Scope]
   )(
     backend: SttpBackend[F, P]
   ) =

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsAccessTokenResponseDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsAccessTokenResponseDeserializationSpec.scala
@@ -28,7 +28,7 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
         accessToken = Secret("TAeJwlzT"),
         domain = Some("mock"),
         expiresIn = 2399.seconds,
-        scope = Scope.refine("secondapp")
+        scope = Some(Scope.refine("secondapp"))
       )
     )
   }
@@ -77,7 +77,7 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
         accessToken = Secret("TAeJwlzT"),
         domain = Some("mock"),
         expiresIn = 2399.seconds,
-        scope = Scope.refine("scope1 scope2")
+        scope = Some(Scope.refine("scope1 scope2"))
       )
 
   }

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsAccessTokenResponseDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsAccessTokenResponseDeserializationSpec.scala
@@ -33,6 +33,27 @@ class ClientCredentialsAccessTokenResponseDeserializationSpec extends AnyFlatSpe
     )
   }
 
+  "Token with no scope" should "be deserialized" in {
+    val json =
+    // language=JSON
+      json"""{
+            "access_token": "TAeJwlzT",
+            "domain": "mock",
+            "expires_in": 2399,
+            "token_type": "Bearer"
+        }"""
+
+    val response = json.as[ClientCredentialsToken.AccessTokenResponse]
+    response shouldBe Right(
+      ClientCredentialsToken.AccessTokenResponse(
+        accessToken = Secret("TAeJwlzT"),
+        domain = Some("mock"),
+        expiresIn = 2399.seconds,
+        scope = None
+      )
+    )
+  }
+
   "Token with empty scope" should "not be deserialized" in {
     val json =
       // language=JSON

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsSpec.scala
@@ -45,7 +45,7 @@ class ClientCredentialsSpec extends AnyWordSpec with Matchers with TryValues wit
 
   "ClientCredentials.requestToken" should {
 
-    val requestToken = ClientCredentials.requestToken[Try](tokenUri, clientId, clientSecret, scope)(_)
+    val requestToken = ClientCredentials.requestToken[Try](tokenUri, clientId, clientSecret, Some(scope))(_)
 
     "successfully request token" in {
       val testingBackend = SttpBackendStub(TryMonad)
@@ -65,7 +65,7 @@ class ClientCredentialsSpec extends AnyWordSpec with Matchers with TryValues wit
         accessToken = Secret("TAeJwlzT"),
         domain = Some("mock"),
         expiresIn = 2399.seconds,
-        scope = Scope.refine("secondapp")
+        scope = Some(Scope.refine("secondapp"))
       )
 
     }

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
@@ -40,6 +40,30 @@ class ClientCredentialsTokenDeserializationSpec extends AnyFlatSpec with Matcher
     )
   }
 
+  "token response JSON without scope" should "be deserialized to proper response" in {
+    val json =
+      // language=JSON
+      json"""{
+            "access_token": "TAeJwlzT",
+            "domain": "mock",
+            "expires_in": 2399,
+            "panda_session_id": "ac097e1f-f927-41df-a776-d824f538351c",
+            "token_type": "Bearer"
+        }"""
+
+    val response = json.as[Either[OAuth2Error, AccessTokenResponse]]
+    response shouldBe Right(
+      Right(
+        ClientCredentialsToken.AccessTokenResponse(
+          accessToken = Secret("TAeJwlzT"),
+          domain = Some("mock"),
+          expiresIn = 2399.seconds,
+          scope = None
+        )
+      )
+    )
+  }
+
   "Token with wrong type" should "not be deserialized" in {
     val json =
       // language=JSON

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/ClientCredentialsTokenDeserializationSpec.scala
@@ -34,7 +34,7 @@ class ClientCredentialsTokenDeserializationSpec extends AnyFlatSpec with Matcher
           accessToken = Secret("TAeJwlzT"),
           domain = Some("mock"),
           expiresIn = 2399.seconds,
-          scope = Scope.refine("cfc.second-app_scope")
+          scope = Some(Scope.refine("cfc.second-app_scope"))
         )
       )
     )


### PR DESCRIPTION
So as per spec. the scope is optional. Introducing and `Option[Scope]` is an API breaking change, however, it keeps it clean.