### PR TITLE
Add keycloak support in AuthorizationCodeProvider

### DIFF
--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AuthorizationCode.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AuthorizationCode.scala
@@ -23,7 +23,7 @@ object AuthorizationCode {
     path: List[String]
   ): Uri =
     baseUri
-      .withPath(path)
+      .addPath(path)
       .addParam("response_type", "code")
       .addParam("client_id", clientId)
       .addParam("redirect_uri", redirectUri)
@@ -32,7 +32,7 @@ object AuthorizationCode {
 
   private def prepareLogoutLink(baseUri: Uri, clientId: String, redirectUri: String, path: List[String]): Uri =
     baseUri
-      .withPath(path)
+      .addPath(path)
       .addParam("client_id", clientId)
       .addParam("redirect_uri", redirectUri)
 

--- a/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AuthorizationCodeProvider.scala
+++ b/oauth2/src/main/scala/com/ocadotechnology/sttp/oauth2/AuthorizationCodeProvider.scala
@@ -107,6 +107,12 @@ object AuthorizationCodeProvider {
       tokenPath = Path(List(Segment("login"), Segment("oauth"), Segment("access_token")))
     )
 
+    val Keycloak: Config = Config(
+      loginPath = Path(List(Segment("protocol"), Segment("openid-connect"), Segment("auth"))),
+      logoutPath = Path(List(Segment("protocol"), Segment("openid-connect"), Segment("logout"))),
+      tokenPath = Path(List(Segment("protocol"), Segment("openid-connect"), Segment("token")))
+    )
+
     // Other predefined configurations for well-known oauth2 providers could be placed here
   }
 
@@ -123,7 +129,7 @@ object AuthorizationCodeProvider {
 
       private val baseUri = refinedUrlToUri(baseUrl)
       private val redirectUri = refinedUrlToUri(redirectUrl)
-      private val tokenUri = baseUri.withPath(pathsConfig.tokenPath.values)
+      private val tokenUri = baseUri.addPath(pathsConfig.tokenPath.values)
 
       override def loginLink(state: Option[String] = None, scope: Set[Scope] = Set.empty): Refined[String, Url] =
         refineV[Url].unsafeFrom[String](
@@ -162,7 +168,7 @@ object AuthorizationCodeProvider {
     backend: SttpBackend[F, Any]
   ): AuthorizationCodeProvider[Uri, F] =
     new AuthorizationCodeProvider[Uri, F] {
-      private val tokenUri = baseUrl.withPath(pathsConfig.tokenPath.values)
+      private val tokenUri = baseUrl.addPath(pathsConfig.tokenPath.values)
 
       override def loginLink(state: Option[String] = None, scope: Set[Scope] = Set.empty): Uri =
         AuthorizationCode

--- a/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/UriUtils.scala
+++ b/oauth2/src/test/scala/com/ocadotechnology/sttp/oauth2/UriUtils.scala
@@ -7,7 +7,7 @@ object UriUtils {
 
   def expectedResult(baseUri: Uri, path: AuthorizationCodeProvider.Config.Path, params: List[(String, String)]): String = {
     val paramsSubstring = params.map((tupleToParam _).tupled).mkString("&")
-    s"${baseUri.withWholePath(s"${path.values.mkString("/")}").toString()}?$paramsSubstring"
+    s"${baseUri.addPath(path.values).toString()}?$paramsSubstring"
   }
 
 }


### PR DESCRIPTION
Keycloak has a concept called [realm](https://www.keycloak.org/docs/latest/server_admin/#configuring-realms) for multi-tenancy.

Realms are part of the uri, so a baseUri looks something like this: `https://<domain>/auth/realms/<realm-name>`. The issue is that `baseUri.withPath` ignores this prefix, so I've changed that to `baseUri.addPath` which should still work fine with other providers.

Keycloak also [supports](https://issues.redhat.com/browse/KEYCLOAK-571) looking up endpoints for login, token, logout etc. through a well-known uri:
`https://<domain>/auth/realms/<realm-name>/.well-known/openid-configuration` but that would a bit require more work so I've just added a static config like for the other providers.